### PR TITLE
Major Bug Fix

### DIFF
--- a/setup.rb
+++ b/setup.rb
@@ -26,5 +26,5 @@ puts "Checking if 'activesupport' is installed..."
 install_check("activesupport")
 puts "Required dependencies for eve7 now installed."
 puts "Opening install script..."
-system("kill #{Process.pid} && ruby install.rb")
+system("kill #{Process.pid}")
 


### PR DESCRIPTION
When calling for [install.rb](https://github.com/Namasteh/Eve-Bot/blob/Eve-7/install.rb) the previous kill signal would interrupt highline/import. Running the file manually may be temporary solution.